### PR TITLE
Conserta sintaxe de testes

### DIFF
--- a/packages/store/tests/setup.ts
+++ b/packages/store/tests/setup.ts
@@ -1,8 +1,8 @@
 import { execSync } from 'child_process';
 
 import * as dotenv from 'dotenv';
-dotenv.config({ path: '../../.env.test' });
+dotenv.config({ path: '../../../.env.test' });
 
 export default async function before() {
-  execSync('docker-compose up -d db && yarn migration:latest ');
+  execSync('docker compose up db --detach && yarn migration:latest ');
 }

--- a/packages/store/tests/teardown.ts
+++ b/packages/store/tests/teardown.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
 
 export default async function after() {
-  execSync('docker-compose down');
+  execSync('docker compose down');
 }


### PR DESCRIPTION
Os testes do store estavam usando uma sintaxe antiga do docker, e o local do arquivo de variáveis de ambiente estava errado.